### PR TITLE
FDN-1849: Add logging etc.

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
@@ -56,9 +56,10 @@ private[http] final class HttpRequestParser(
     override def onPush(): Unit = handleParserOutput(parseSessionBytes(grab(in)))
     override def onPull(): Unit = handleParserOutput(doPull())
 
-    override def onUpstreamFinish(): Unit =
-      if (super.shouldComplete()) completeStage()
+    override def onUpstreamFinish(): Unit = {
+      if (super.shouldComplete("HttpRequestParser")) completeStage()
       else if (isAvailable(out)) handleParserOutput(doPull())
+    }
 
     setHandlers(in, out, this)
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -36,7 +36,7 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings, p
 
   final def onPull(): ResponseOutput = doPull()
 
-  final def onUpstreamFinish(): Boolean = shouldComplete()
+  final def onUpstreamFinish(): Boolean = shouldComplete("HttpResponseParser")
 
   override final def emit(output: ResponseOutput): Unit = {
     if (output == MessageEnd) contextForCurrentResponse = None


### PR DESCRIPTION
Built with JDK8 (some tests wouldn't work otherwise).

Some example of the new logs from the output of running ClientServerSpec.

(1) A request without complete body (probably what happens to us):

```
DEBUG uuid=4e6023fd-c489-4da6-86db-e809b1f2ad08 calling parseEntity with contentLength=None isChunked=true
DEBUG uuid=4e6023fd-c489-4da6-86db-e809b1f2ad08 emit: RequestStart(HttpMethod(PUT),/,HttpProtocol(HTTP/1.1),List(Host: 127.20.7.17:40287,
 User-Agent: akka-http/10.1.15+1-aac30ecf-SNAPSHOT),<function1>,false,false)
DEBUG uuid=4e6023fd-c489-4da6-86db-e809b1f2ad08 emitting error from HttpRequestParser with result null
DEBUG uuid=4e6023fd-c489-4da6-86db-e809b1f2ad08 emit: EntityStreamError(akka.http.scaladsl.model.ErrorInfo@50308e9d)
```

(2) A request with complete body:

```
DEBUG uuid=779f1968-3623-4263-8982-20f5e1768db4 calling parseEntity with contentLength=None isChunked=true
DEBUG uuid=779f1968-3623-4263-8982-20f5e1768db4 emit: RequestStart(HttpMethod(POST),/chunked,HttpProtocol(HTTP/1.1),List(Accept: */*, Host: 127.20.156.248:36145, User-Agent: akka-http/10.1.15+1-aac30ecf-SNAPSHOT),<function1>,false,false)
DEBUG uuid=779f1968-3623-4263-8982-20f5e1768db4 emit: EntityChunk(Chunk(ByteString(97, 98, 99),))
DEBUG uuid=779f1968-3623-4263-8982-20f5e1768db4 emit: EntityChunk(Chunk(ByteString(100, 101, 102, 103),))
DEBUG uuid=779f1968-3623-4263-8982-20f5e1768db4 emit: EntityChunk(Chunk(ByteString(104, 105, 106, 107, 108),))
DEBUG uuid=779f1968-3623-4263-8982-20f5e1768db4 emit: EntityChunk(LastChunk(,List()))
DEBUG uuid=779f1968-3623-4263-8982-20f5e1768db4 emit: MessageEnd
```

(3) A response:

```
DEBUG uuid=c087b64a-512f-434d-873d-c84f11b3cdb4 calling parseEntity with contentLength=Some(Content-Length: 200000) isChunked=false
DEBUG uuid=c087b64a-512f-434d-873d-c84f11b3cdb4 emit: ResponseStart(200 OK,HttpProtocol(HTTP/1.1),List(Server: akka-http/10.1.15+1-aac30e
cf-SNAPSHOT, Date: Thu, 26 Oct 2023 13:44:33 GMT, Connection: close),<function1>,true)
DEBUG uuid=c087b64a-512f-434d-873d-c84f11b3cdb4 emit: EntityPart(len(data)=965)
DEBUG uuid=c087b64a-512f-434d-873d-c84f11b3cdb4 emit: EntityPart(len(data)=1152)
DEBUG uuid=c087b64a-512f-434d-873d-c84f11b3cdb4 emit: EntityPart(len(data)=1152)
...
DEBUG uuid=c087b64a-512f-434d-873d-c84f11b3cdb4 emit: MessageEnd
```
